### PR TITLE
add protection against dns rebinding

### DIFF
--- a/anti_SSRF_requests_adapter.py
+++ b/anti_SSRF_requests_adapter.py
@@ -1,31 +1,55 @@
+import ssl
+
 import requests
-from requests.adapters import HTTPAdapter
+from requests.adapters import HTTPAdapter, DEFAULT_POOLBLOCK, DEFAULT_POOLSIZE, DEFAULT_RETRIES, BaseAdapter
 import socket
 import ipaddress
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
+import certifi
+
+from urllib3 import PoolManager, Retry
+
 
 class AntiSSRFRequestAdapter(HTTPAdapter):
     def __init__(self, *args, **kwargs):
-        self.resolved_ips = {}
         super(AntiSSRFRequestAdapter, self).__init__(*args, **kwargs)
 
     def init_poolmanager(self, *args, **kwargs):
         self.poolmanager = requests.packages.urllib3.poolmanager.PoolManager(*args, **kwargs)
 
-    def send(self, request, **kwargs):
-        hostname = urlparse(request.url).hostname
-        if hostname not in self.resolved_ips:
+
+class AntiSSRFSession:
+    def __init__(self):
+        self.session = requests.Session()
+        self.session.mount('http://', AntiSSRFRequestAdapter())
+        self.session.mount('https://', AntiSSRFRequestAdapter())
+
+    def get(self, url, **kwargs):
+        kwargs['allow_redirects'] = False
+        parsedURL = urlparse(url)
+        hostname = parsedURL.hostname
+        # first validate hostname SSL because we want to send the https request directly to IP address
+        self.verify_ssl_certificate(hostname)
+        ip = ""
+        if hostname:
             try:
                 ip = socket.gethostbyname(hostname)
                 if ':' in ip:  # Check for IPv6
                     raise ValueError(f"IPv6 addresses are disallowed: {ip}")
                 if self.is_disallowed_ip(ip):
-                    raise ValueError(f"Access to {request.url} is blocked due to disallowed IP {ip}")
-                self.resolved_ips[hostname] = ip
+                    raise ValueError(f"Access to {url} is blocked due to disallowed IP {ip}")
             except socket.gaierror:  # Handle resolution errors
                 raise ValueError(f"Error resolving {hostname}")
-
-        return super(AntiSSRFRequestAdapter, self).send(request, **kwargs)
+        if parsedURL.port:
+            new_url = urlunparse(
+                (parsedURL.scheme, ip + ":" + str(parsedURL.port), parsedURL.path, parsedURL.params,
+                 parsedURL.query, parsedURL.fragment))
+        else:
+            new_url = urlunparse(
+                (parsedURL.scheme, ip, parsedURL.path, parsedURL.params,
+                 parsedURL.query, parsedURL.fragment))
+        return self.session.get(new_url, headers={"host": hostname},
+                                **kwargs)
 
     def is_disallowed_ip(self, ip):
         disallowed_networks = [
@@ -39,26 +63,30 @@ class AntiSSRFRequestAdapter(HTTPAdapter):
         ip_addr = ipaddress.ip_address(ip)
         return any(ip_addr in network for network in disallowed_networks)
 
-class AntiSSRFSession:
-    def __init__(self):
-        self.session = requests.Session()
-        adapter = AntiSSRFRequestAdapter()
-        self.session.mount('http://', adapter)
-        self.session.mount('https://', adapter)
+    def verify_ssl_certificate(self, hostname):
+        context = ssl.create_default_context(cafile=certifi.where())
 
-    def get(self, url, **kwargs):
-        kwargs['allow_redirects'] = False
-        return self.session.get(url, **kwargs)
+        with socket.create_connection((hostname, 443)) as sock:
+            try:
+                with context.wrap_socket(sock, server_hostname=hostname) as ssock:
+                    ssock.do_handshake()
+                    ssock.getpeercert()
+            except ssl.SSLCertVerificationError as err:
+                raise ValueError(f"Error validating SSL {hostname}")
+            print("Certificate is valid.")
 
     # TBD: Implement other HTTP methods here..
 
 
 assrf_session = AntiSSRFSession()
 
+
 def main():
     try:
-        response = assrf_session.get('http://example.com')
+        response = assrf_session.get('https://www.google.com/', verify=False)
         print(response.content)
+        # response = requests.get('https://google.com/')
+        # print(response.content)
     except ValueError as e:
         print(f"An error occurred: {e}")
 

--- a/anti_SSRF_requests_adapter.py
+++ b/anti_SSRF_requests_adapter.py
@@ -1,7 +1,7 @@
 import ssl
 
 import requests
-from requests.adapters import HTTPAdapter, DEFAULT_POOLBLOCK, DEFAULT_POOLSIZE, DEFAULT_RETRIES, BaseAdapter
+from requests.adapters import HTTPAdapter
 import socket
 import ipaddress
 from urllib.parse import urlparse, urlunparse

--- a/anti_SSRF_requests_adapter.py
+++ b/anti_SSRF_requests_adapter.py
@@ -7,8 +7,6 @@ import ipaddress
 from urllib.parse import urlparse, urlunparse
 import certifi
 
-from urllib3 import PoolManager, Retry
-
 
 class AntiSSRFRequestAdapter(HTTPAdapter):
     def __init__(self, *args, **kwargs):
@@ -48,7 +46,7 @@ class AntiSSRFSession:
             new_url = urlunparse(
                 (parsedURL.scheme, ip, parsedURL.path, parsedURL.params,
                  parsedURL.query, parsedURL.fragment))
-        return self.session.get(new_url, headers={"host": hostname},
+        return self.session.get(new_url, headers={"host": hostname}, verify=False,
                                 **kwargs)
 
     def is_disallowed_ip(self, ip):
@@ -83,10 +81,8 @@ assrf_session = AntiSSRFSession()
 
 def main():
     try:
-        response = assrf_session.get('https://www.google.com/', verify=False)
+        response = assrf_session.get('https://www.google.com/')
         print(response.content)
-        # response = requests.get('https://google.com/')
-        # print(response.content)
     except ValueError as e:
         print(f"An error occurred: {e}")
 


### PR DESCRIPTION
validate the SSL certificate separately by the `verify_ssl_certificate` method, then send the HTTPS request directly to the IP address with the `verify=False` option.